### PR TITLE
Provide List.map from runtime and include that for serializing lists

### DIFF
--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -38,9 +38,6 @@ let parse_options options =
     | _ -> raise_errorf ~loc:expr.pexp_loc "%s does not support option %s" deriver name);
   !strict
 
-let wrap_runtime decls =
-  [%expr let open Ppx_deriving_yojson_runtime in [%e decls]]
-
 let rec ser_expr_of_typ typ =
   let attr_int_encoding typ =
     match attr_int_encoding typ with `String -> "String" | `Int -> "Intlit"
@@ -207,6 +204,9 @@ and desu_expr_of_typ ~path typ =
   | { ptyp_loc } ->
     raise_errorf ~loc:ptyp_loc "%s cannot be derived for %s"
                  deriver (Ppx_deriving.string_of_core_type typ)
+
+let wrap_runtime decls =
+  [%expr let open Ppx_deriving_yojson_runtime in [%e decls]]
 
 let ser_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
   ignore (parse_options options);

--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -348,7 +348,7 @@ let ser_str_of_type_ext ~options ~path ({ ptyext_path = { loc }} as type_ext) =
     String.concat "." (Longident.flatten mod_lid)
   in
   let polymorphize = Ppx_deriving.poly_fun_of_type_ext type_ext in
-  let serializer = polymorphize serializer in
+  let serializer = polymorphize (wrap_runtime serializer) in
 
   let flid = lid (Printf.sprintf "%s.f" mod_name) in
   let set_field = Exp.setfield (Exp.ident flid) flid serializer in

--- a/src/ppx_deriving_yojson_runtime.ml
+++ b/src/ppx_deriving_yojson_runtime.ml
@@ -8,3 +8,12 @@ let rec map_bind f acc xs =
   match xs with
   | x :: xs -> f x >>= fun x -> map_bind f (x :: acc) xs
   | [] -> `Ok (List.rev acc)
+
+
+module List = List
+module String = String
+module Bytes = Bytes
+module Int32 = Int32
+module Int64 = Int64
+module Nativeint = Nativeint
+module Array = Array

--- a/src/ppx_deriving_yojson_runtime.mli
+++ b/src/ppx_deriving_yojson_runtime.mli
@@ -6,3 +6,11 @@ val ( >|= ) :
 val map_bind :
   ('a -> [ `Error of 'b | `Ok of 'c ]) ->
   'c list -> 'a list -> [ `Error of 'b | `Ok of 'c list ]
+
+module List : (module type of List)
+module String : (module type of String)
+module Bytes : (module type of Bytes)
+module Int32 : (module type of Int32)
+module Int64 : (module type of Int64)
+module Nativeint : (module type of Nativeint)
+module Array : (module type of Array)

--- a/src_test/test_ppx_yojson.ml
+++ b/src_test/test_ppx_yojson.ml
@@ -253,6 +253,28 @@ let test_opentype ctxt =
   assert_roundtrip pp_ot to_yojson of_yojson
                    (C (Opentype.A 42, 1.2)) "[\"C\", [\"A\", 42], 1.2]"
 
+
+module TestShadowing = struct
+  module List = struct
+    let map () = ()
+  end
+
+  type t = int list [@@deriving yojson]
+
+  module Array = struct
+    let to_list () = ()
+  end
+
+  module Bytes = struct
+    let to_string () = ()
+  end
+
+  type v = bytes [@@deriving yojson]
+
+end
+
+
+
 let suite = "Test ppx_yojson" >::: [
     "test_int"       >:: test_int;
     "test_float"     >:: test_float;


### PR DESCRIPTION
Currently, ppx_deriving_yojson fails to compile if whatever `List.map` you have in scope does not have the type signature `('a -> 'b) -> 'a list -> 'b list`. In particular, this means that if you are using `Core` or `Core_kernel`, you'll get compile errors (as they use labeled arguments for the function, and reverse the order). 

In general, it seems risky to generate identifiers in code that could be overridden by user code. This pull request fixes this particular case by adding a `List` module with the requisite `map` function to the runtime module and opening that module in the generated serializers. But it would also be worthwhile to check if there are any other cases that could use this treatment.

I wasn't sure if the place that I put the call to `wrap_runtime` is best. Let me know if it should go somewhere else. 

The test for this will not compile without the fix (so it is a test that runs in the type system, rather than through oUnit).