### PR TITLE
make: put arguments to 'rm' before target directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ build:
 	ocaml pkg/build.ml native=true native-dynlink=true
 
 test: build
-	rm _build/src_test/ -rf
+	rm -rf _build/src_test/
 	ocamlbuild -j 0 -use-ocamlfind -classic-display \
 						 src_test/test_ppx_yojson.byte --
 


### PR DESCRIPTION
BSD rm (confirmed here on FreeBSD) requires that the options to `rm` precede the target directories. Since GNU rm doesn't care, this seems like a good thing to fix (as otherwise, BSD users can't run the tests!).