### PR TITLE
Fix inheriting-case of polymorphic variants

### DIFF
--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -183,12 +183,13 @@ and desu_expr_of_typ ~path typ =
           raise_errorf ~loc:ptyp_loc "%s cannot be derived for %s"
                        deriver (Ppx_deriving.string_of_core_type typ))
     and inherits_case =
+      let toplevel_typ = typ in
       inherits |>
       List.map (function Rinherit typ -> typ | _ -> assert false) |>
       List.fold_left (fun expr typ ->
         [%expr
           match [%e desu_expr_of_typ ~path typ] json with
-          | (`Ok _) as result -> result
+          | (`Ok result) -> `Ok (result :> [%t toplevel_typ])
           | `Error _ -> [%e expr]]) error |>
       Exp.case [%pat? _]
     in

--- a/src_test/test_ppx_yojson.ml
+++ b/src_test/test_ppx_yojson.ml
@@ -285,6 +285,19 @@ module TestShadowing = struct
 end
 
 
+module Test_recursive_polyvariant = struct
+  (* Regression test for 
+     https://github.com/whitequark/ppx_deriving_yojson/issues/24 *)
+  type a = [ `B of string ] 
+      [@@deriving of_yojson]
+  type b = [a | `C of b list]
+      [@@deriving of_yojson]
+  type c = [ a | b | `D of b list]
+      [@@deriving of_yojson]
+  let c_of_yojson yj : [ `Ok of c | `Error of string ] = c_of_yojson yj
+end
+
+
 
 let suite = "Test ppx_yojson" >::: [
     "test_int"       >:: test_int;


### PR DESCRIPTION
This fixes #24 with the coercion:

    `Ok result -> `Ok (result :> toplevel_type)

(It's my first attempt at using `ppx_tools`)

