### PR TITLE
Deal with recursive types

### DIFF
--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -66,11 +66,11 @@ let rec ser_expr_of_typ typ =
     [%expr function None -> `Null | Some x -> [%e ser_expr_of_typ typ] x]
   | [%type: Yojson.Safe.json] -> [%expr fun x -> x]
   | { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
-     let fwd = app (Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Suffix "to_yojson") lid)))
-                   (List.map ser_expr_of_typ args)
-     in
-     (* eta-expansion is necessary for let-rec *)
-     [%expr fun x -> [%e fwd] x]
+    let fwd = app (Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Suffix "to_yojson") lid)))
+        (List.map ser_expr_of_typ args)
+    in
+    (* eta-expansion is necessary for let-rec *)
+    [%expr fun x -> [%e fwd] x]
        
   | { ptyp_desc = Ptyp_tuple typs } ->
     [%expr fun [%p ptuple (List.mapi (fun i _ -> pvar (argn i)) typs)] ->

--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -43,6 +43,7 @@ let rec ser_expr_of_typ typ =
     match attr_int_encoding typ with `String -> "String" | `Int -> "Intlit"
   in
   match typ with
+  | [%type: unit]            -> [%expr fun x -> `Null]
   | [%type: int]             -> [%expr fun x -> `Int x]
   | [%type: float]           -> [%expr fun x -> `Float x]
   | [%type: bool]            -> [%expr fun x -> `Bool x]
@@ -118,6 +119,7 @@ and desu_expr_of_typ ~path typ =
   in
   let decode pat exp = decode' [pat, exp] in
   match typ with
+  | [%type: unit]   -> decode [%pat? `Null] [%expr `Ok ()]
   | [%type: int]    -> decode [%pat? `Int x]    [%expr `Ok x]
   | [%type: float]  ->
     decode' [[%pat? `Int x],    [%expr `Ok (float_of_int x)];

--- a/src_test/test_ppx_yojson.ml
+++ b/src_test/test_ppx_yojson.ml
@@ -13,6 +13,7 @@ let assert_failure pp_obj of_json err str =
   let json = Yojson.Safe.from_string str in
   assert_equal ~printer:(show_error_or pp_obj) (`Error err) (of_json json)
 
+type u = unit         [@@deriving show, yojson]
 type i1 = int         [@@deriving show, yojson]
 type i2 = int32       [@@deriving show, yojson]
 type i3 = Int32.t     [@@deriving show, yojson]
@@ -48,6 +49,10 @@ type v  = A | B of int | C of int * string
 [@@deriving show, yojson]
 type r  = { x : int; y : string }
 [@@deriving show, yojson]
+
+let test_unit ctxt =
+  assert_roundtrip pp_u u_to_yojson u_of_yojson
+                   () "null"
 
 let test_int ctxt =
   assert_roundtrip pp_i1 i1_to_yojson i1_of_yojson
@@ -334,6 +339,7 @@ end
 
 
 let suite = "Test ppx_yojson" >::: [
+    "test_unit"      >:: test_unit;
     "test_int"       >:: test_int;
     "test_int_edge"  >:: test_int_edge;
     "test_float"     >:: test_float;

--- a/src_test/test_ppx_yojson.ml
+++ b/src_test/test_ppx_yojson.ml
@@ -49,11 +49,11 @@ type v  = A | B of int | C of int * string
 [@@deriving show, yojson]
 type r  = { x : int; y : string }
 [@@deriving show, yojson]
-
+           
 let test_unit ctxt =
   assert_roundtrip pp_u u_to_yojson u_of_yojson
                    () "null"
-
+                   
 let test_int ctxt =
   assert_roundtrip pp_i1 i1_to_yojson i1_of_yojson
                    42 "42";
@@ -336,7 +336,22 @@ module Test_recursive_polyvariant = struct
   let c_of_yojson yj : [ `Ok of c | `Error of string ] = c_of_yojson yj
 end
 
+type 'a recursive1 = { lhs : string ; rhs : 'a }
+ and foo = unit recursive1
+ and bar = int recursive1 
+               [@@deriving show, yojson]
+    
+let test_recursive ctxt =
+  assert_roundtrip (pp_recursive1 pp_i1)
+                   (recursive1_to_yojson i1_to_yojson)
+                   (recursive1_of_yojson i1_of_yojson)                                   
+                   {lhs="x"; rhs=42} "{\"lhs\":\"x\",\"rhs\":42}";
 
+  assert_roundtrip pp_foo foo_to_yojson foo_of_yojson                                      
+                   {lhs="x"; rhs=()} "{\"lhs\":\"x\",\"rhs\":null}" ;
+
+  assert_roundtrip pp_bar bar_to_yojson bar_of_yojson                                      
+                   {lhs="x"; rhs=42} "{\"lhs\":\"x\",\"rhs\":42}"
 
 let suite = "Test ppx_yojson" >::: [
     "test_unit"      >:: test_unit;
@@ -365,7 +380,8 @@ let suite = "Test ppx_yojson" >::: [
     "test_shortcut"  >:: test_shortcut;
     "test_nostrict"  >:: test_nostrict;
     "test_opentype"  >:: test_opentype;
-  ]
+    "test_recursive" >:: test_recursive;
+    ]
 
 let _ =
   run_test_tt_main suite

--- a/src_test/test_ppx_yojson.ml
+++ b/src_test/test_ppx_yojson.ml
@@ -49,11 +49,11 @@ type v  = A | B of int | C of int * string
 [@@deriving show, yojson]
 type r  = { x : int; y : string }
 [@@deriving show, yojson]
-           
+     
 let test_unit ctxt =
   assert_roundtrip pp_u u_to_yojson u_of_yojson
-                   () "null"
-                   
+    () "null"
+
 let test_int ctxt =
   assert_roundtrip pp_i1 i1_to_yojson i1_of_yojson
                    42 "42";
@@ -381,7 +381,7 @@ let suite = "Test ppx_yojson" >::: [
     "test_nostrict"  >:: test_nostrict;
     "test_opentype"  >:: test_opentype;
     "test_recursive" >:: test_recursive;
-    ]
+  ]
 
 let _ =
   run_test_tt_main suite


### PR DESCRIPTION
This is basically the application of https://github.com/whitequark/ppx_deriving/issues/23 to the yojson plugin.

It is required to apply https://github.com/whitequark/ppx_deriving/pull/49 to ppx_deriving first, since yojson generates variant types.

The stuff about dealing with unit is somewhat unrelated, but was necessary for my scenario, and since github does not easily handle multiple forks ...