### PR TITLE
Switch to using result

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,1 +1,1 @@
-PKG compiler-libs.common ppx_deriving.api ppx_import oUnit yojson
+PKG compiler-libs.common ppx_deriving.api ppx_import oUnit yojson result ppx_tools.metaquot

--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 true: warn(@5@8@10@11@12@14@23@24@26@29@40), bin_annot, safe_string
 
 "src": include
-<src/*.{ml,mli,byte,native}>: package(ppx_tools.metaquot), package(ppx_deriving.api)
-<src_test/*.{ml,byte,native}>: debug, package(oUnit), package(yojson), use_yojson, use_ppx_deriving_yojson_runtime
+<src/*.{ml,mli,byte,native}>: package(ppx_tools.metaquot), package(ppx_deriving.api), package(result)
+<src_test/*.{ml,byte,native}>: debug, package(result), package(oUnit), package(yojson), use_yojson, use_ppx_deriving_yojson_runtime

--- a/opam
+++ b/opam
@@ -19,6 +19,7 @@ build-test: [
 ]
 depends: [
   "yojson"
+  "result"
   "ppx_deriving" {>= "2.0" & < "4.0"}
   "ocamlfind"    {build}
   "ounit"        {test}

--- a/pkg/META.in
+++ b/pkg/META.in
@@ -10,7 +10,7 @@ exists_if = "ppx_deriving_yojson.cma"
 package "runtime" (
   version = "%{version}%"
   description = "Runtime components of [@@deriving yojson]"
-  requires = "yojson"
+  requires = "yojson result"
   archive(byte) = "ppx_deriving_yojson_runtime.cma"
   archive(byte, plugin) = "ppx_deriving_yojson_runtime.cma"
   archive(native) = "ppx_deriving_yojson_runtime.cmxa"

--- a/src/ppx_deriving_yojson_runtime.ml
+++ b/src/ppx_deriving_yojson_runtime.ml
@@ -1,19 +1,24 @@
+include Ppx_deriving_runtime
+
 let (>>=) x f =
-  match x with `Ok x -> f x | (`Error _) as x -> x
+  match x with Result.Ok x -> f x | (Result.Error _) as x -> x
 
 let (>|=) x f =
-  x >>= fun x -> `Ok (f x)
+  x >>= fun x -> Result.Ok (f x)
 
 let rec map_bind f acc xs =
   match xs with
   | x :: xs -> f x >>= fun x -> map_bind f (x :: acc) xs
-  | [] -> `Ok (List.rev acc)
+  | [] -> Result.Ok (List.rev acc)
 
+type 'a error_or = ('a, string) Result.result
 
-module List = List
-module String = String
-module Bytes = Bytes
-module Int32 = Int32
-module Int64 = Int64
-module Nativeint = Nativeint
-module Array = Array
+let show_error_or f = function
+  | Result.Error s -> "Error: " ^ s
+  | Result.Ok x -> f x
+
+let pp_error_or pp_x fmt = function
+  | Result.Ok x -> pp_x fmt x
+  | Result.Error e ->
+    Format.pp_print_string fmt "Error ";
+    Format.pp_print_string fmt e

--- a/src/ppx_deriving_yojson_runtime.mli
+++ b/src/ppx_deriving_yojson_runtime.mli
@@ -1,11 +1,14 @@
-val ( >>= ) :
-  [ `Error of 'a | `Ok of 'b ] -> ('b -> ([> `Error of 'a ] as 'c)) -> 'c
-val ( >|= ) :
-  [ `Error of 'a | `Ok of 'b ] ->
-  ('b -> 'c) -> [ `Error of 'a | `Ok of 'c ]
-val map_bind :
-  ('a -> [ `Error of 'b | `Ok of 'c ]) ->
-  'c list -> 'a list -> [ `Error of 'b | `Ok of 'c list ]
+type 'a error_or = ('a, string) Result.result
+
+val pp_error_or
+  : (Format.formatter -> 'a -> unit)
+  -> Format.formatter
+  -> 'a error_or
+  -> unit
+
+val ( >>= ) : 'a error_or -> ('a -> 'b error_or) -> 'b error_or
+val ( >|= ) : 'a error_or -> ('a -> 'b) -> 'b error_or
+val map_bind : ('a -> 'b error_or) -> 'b list -> 'a list -> 'b list error_or
 
 module List : (module type of List)
 module String : (module type of String)
@@ -14,3 +17,8 @@ module Int32 : (module type of Int32)
 module Int64 : (module type of Int64)
 module Nativeint : (module type of Nativeint)
 module Array : (module type of Array)
+module Result : sig
+  type ('a, 'b) result = ('a, 'b) Result.result =
+    | Ok of 'a
+    | Error of 'b
+end


### PR DESCRIPTION
Switch from polymorphic variant version of result to the standard one.

This is breaking a change but I think there's a manageable number of packages
to fix:
```
ketrew
key-parsers
ojs-base
ppx_json_types
socket-daemon
```
@nv-vn @zoggy @smondet @emillon 