### PR TITLE
Add ppx_deriving.runtime to requires in META

### DIFF
--- a/pkg/META.in
+++ b/pkg/META.in
@@ -10,7 +10,7 @@ exists_if = "ppx_deriving_yojson.cma"
 package "runtime" (
   version = "%{version}%"
   description = "Runtime components of [@@deriving yojson]"
-  requires = "yojson result"
+  requires = "yojson result ppx_deriving.runtime"
   archive(byte) = "ppx_deriving_yojson_runtime.cma"
   archive(byte, plugin) = "ppx_deriving_yojson_runtime.cma"
   archive(native) = "ppx_deriving_yojson_runtime.cmxa"


### PR DESCRIPTION
Without this, it is impossible to use `ppx_deriving.runtime` by itself.
For example `utop` would fail with the following error:

```
utop -require ppx_deriving_yojson.runtime
File "_none_", line 1:
Error: Reference to undefined global `Ppx_deriving_runtime'
```

Thanks!