### PR TITLE
Support record variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,6 @@ Variants (regular and polymorphic) are represented using arrays; the first eleme
 
 By default, objects are deserialized strictly; that is, all keys in the object have to correspond to fields of the record. Passing `strict = false` as an option to the deriver  (i.e. `[@@deriving yojson { strict = false }]`) changes the behavior to ignore any unknown fields.
 
-### Options
-
-Option attribute names may be prefixed with `yojson.` to avoid conflicts with other derivers.
-
 ### Record variants
 
 OCaml 4.03 introduced record variants, like `type t = X of { field : type }`.
@@ -88,6 +84,10 @@ These are handled as if the record was defined independently, i.e.
 Because of the implementers' laziness, record variants do not work yet
 for extensible types (when you extend with `type t += ...`). A patch
 would be welcome.
+
+### Options
+
+Option attribute names may be prefixed with `yojson.` to avoid conflicts with other derivers.
 
 #### [@key]
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ By default, objects are deserialized strictly; that is, all keys in the object h
 
 Option attribute names may be prefixed with `yojson.` to avoid conflicts with other derivers.
 
+### Record variants
+
+OCaml 4.03 introduced record variants, like `type t = X of { field : type }`.
+These are handled as if the record was defined independently, i.e.
+`type t = X of t_record and t_record = { field : type }`.
+
+Because of the implementers' laziness, record variants do not work yet
+for extensible types (when you extend with `type t += ...`). A patch
+would be welcome.
+
 #### [@key]
 
 If the JSON object keys differ from OCaml conventions, lexical or otherwise, it is possible to specify the corresponding JSON key implicitly using <code>[@key "field"]</code>, e.g.:

--- a/src/ppx_deriving_yojson.cppo.ml
+++ b/src/ppx_deriving_yojson.cppo.ml
@@ -421,21 +421,12 @@ let desu_str_of_record ~is_strict ~error ~path wrap_record labels =
       (fun expr i ->
         [%expr [%e evar (argn i)] >>= fun [%p pvar (argn i)] -> [%e expr]]
       )
-      [%expr
-        Result.Ok
-          [%e
-            wrap_record
-              (Exp.record
-                (labels |>
-                   List.mapi
-                     (fun i { pld_name = { txt = name } } ->
-                       mknoloc (Lident name), evar (argn i)
-                     )
-                )
-                None
-              )
-          ]
-      ]
+      ( let r =
+          Exp.record (labels |>
+            List.mapi (fun i { pld_name = { txt = name } } ->
+              mknoloc (Lident name), evar (argn i)))
+            None in
+        [%expr Result.Ok [%e wrap_record r] ] )
       (labels |> List.mapi (fun i _ -> i)) in
   let default_case = if is_strict then top_error else [%expr loop xs _state] in
   let cases =

--- a/src_test/test_ppx_yojson.cppo.ml
+++ b/src_test/test_ppx_yojson.cppo.ml
@@ -55,8 +55,10 @@ type v  = A | B of int | C of int * string
 [@@deriving show, yojson]
 type r  = { x : int; y : string }
 [@@deriving show, yojson]
+#if OCAML_VERSION >= (4, 03, 0)
 type rv = RA | RB of int | RC of int * string | RD of { z : string }
 [@@deriving show, yojson]
+#endif
 
 let test_unit ctxt =
   assert_roundtrip pp_u u_to_yojson u_of_yojson
@@ -178,6 +180,7 @@ let test_rec ctxt =
   assert_roundtrip pp_r r_to_yojson r_of_yojson
                    {x=42; y="foo"} "{\"x\":42,\"y\":\"foo\"}"
 
+#if OCAML_VERSION >= (4, 03, 0)
 let test_recvar ctxt =
   assert_roundtrip pp_rv rv_to_yojson rv_of_yojson
                    RA "[\"RA\"]";
@@ -187,6 +190,7 @@ let test_recvar ctxt =
                    (RC(42, "foo")) "[\"RC\", 42, \"foo\"]";
   assert_roundtrip pp_rv rv_to_yojson rv_of_yojson
                    (RD{z="foo"}) "[\"RD\", {\"z\": \"foo\"}]"
+#endif
 
 type geo = {
   lat : float [@key "Latitude"]  ;
@@ -388,7 +392,9 @@ let suite = "Test ppx_yojson" >::: [
     "test_pvar"      >:: test_pvar;
     "test_var"       >:: test_var;
     "test_rec"       >:: test_rec;
+#if OCAML_VERSION >= (4, 03, 0)
     "test_recvar"    >:: test_recvar;
+#endif
     "test_key"       >:: test_key;
     "test_id"        >:: test_id;
     "test_custvar"   >:: test_custvar;

--- a/src_test/test_ppx_yojson.ml
+++ b/src_test/test_ppx_yojson.ml
@@ -55,6 +55,8 @@ type v  = A | B of int | C of int * string
 [@@deriving show, yojson]
 type r  = { x : int; y : string }
 [@@deriving show, yojson]
+type rv = RA | RB of int | RC of int * string | RD of { z : string }
+[@@deriving show, yojson]
 
 let test_unit ctxt =
   assert_roundtrip pp_u u_to_yojson u_of_yojson
@@ -175,6 +177,16 @@ let test_var ctxt =
 let test_rec ctxt =
   assert_roundtrip pp_r r_to_yojson r_of_yojson
                    {x=42; y="foo"} "{\"x\":42,\"y\":\"foo\"}"
+
+let test_recvar ctxt =
+  assert_roundtrip pp_rv rv_to_yojson rv_of_yojson
+                   RA "[\"RA\"]";
+  assert_roundtrip pp_rv rv_to_yojson rv_of_yojson
+                   (RB 42) "[\"RB\", 42]";
+  assert_roundtrip pp_rv rv_to_yojson rv_of_yojson
+                   (RC(42, "foo")) "[\"RC\", 42, \"foo\"]";
+  assert_roundtrip pp_rv rv_to_yojson rv_of_yojson
+                   (RD{z="foo"}) "[\"RD\", {\"z\": \"foo\"}]"
 
 type geo = {
   lat : float [@key "Latitude"]  ;
@@ -376,6 +388,7 @@ let suite = "Test ppx_yojson" >::: [
     "test_pvar"      >:: test_pvar;
     "test_var"       >:: test_var;
     "test_rec"       >:: test_rec;
+    "test_recvar"    >:: test_recvar;
     "test_key"       >:: test_key;
     "test_id"        >:: test_id;
     "test_custvar"   >:: test_custvar;


### PR DESCRIPTION
For example,  `type t = X of { field : typ }`

No support, though, if these variants are used in extensible types
(`type t = ..;; type t += X of { field : typ }`)

Changes in the serializer: I factored out the code generating the code for records (into `ser_str_of_record`).  The name of the variable - formerly always "x" - is now an argument.

Changes in the deserializer: Similarly, there is now also `desu_str_of_record`. The code allows it to wrap the record, because for record variants the name of the variant needs to be inserted somehow (we generate `X { field = ... }` instead of just `{ field = ... }` in the record variant case).